### PR TITLE
added min required subscribed fields for messenger bot

### DIFF
--- a/lib/rubotnik.rb
+++ b/lib/rubotnik.rb
@@ -25,12 +25,12 @@ module Rubotnik
 
     def logger
       @logger ||= Logger.new($stdout).tap do |log|
-        log.progname = self.name
+        log.progname = name
       end
     end
 
     def route(event, &block)
-      if [:message, :postback].include?(event)
+      if %i[message postback].include?(event)
         Bot.on event do |e|
           case e
           when Facebook::Messenger::Incoming::Message
@@ -45,7 +45,10 @@ module Rubotnik
     end
 
     def subscribe(token)
-      Facebook::Messenger::Subscriptions.subscribe(access_token: token)
+      Facebook::Messenger::Subscriptions.subscribe(
+        access_token: token,
+        subscribed_fields: %w[messages messaging_postbacks]
+      )
     end
 
     def set_profile(*payloads)

--- a/spec/rubotnik_spec.rb
+++ b/spec/rubotnik_spec.rb
@@ -20,9 +20,13 @@ RSpec.describe Rubotnik do
 
   describe 'subscribe' do
     it 'subscribes to a fb page' do
+      subscribed_fields = %w[messages messaging_postbacks]
       token = 'xxx'
       expect(Facebook::Messenger::Subscriptions)
-        .to receive(:subscribe).with(access_token: token)
+        .to receive(:subscribe).with(
+          access_token: token,
+          subscribed_fields: subscribed_fields
+        )
 
       described_class.subscribe(token)
     end


### PR DESCRIPTION
Fixes #23. 
Background: the facebook-messenger gem [doesn't set](https://github.com/jgorset/facebook-messenger/blob/620ed51bcd3c5eb87623ccd37f11ab0cb7dcf379/lib/facebook/messenger/subscriptions.rb#L30) any default values for `subscribed_fields` but the FB API expects at least one. FB API response:
```
"(#100) Param subscribed_fields[0] must be one of {feed, mention, name, ...}."
```

I didn't want to change the Rubotnik API so I hardcoded the two required subscriptions when calling `Rubotnik.subscribe(TOKEN)`
